### PR TITLE
Top and centre alignment of "BALANCE" in mysolarpv

### DIFF
--- a/Modules/app/mysolarpv/mysolarpv.html
+++ b/Modules/app/mysolarpv/mysolarpv.html
@@ -34,15 +34,15 @@
 
     <table style="width:100%">
     <tr>
-        <td style="text-align:left; border:0; width=33%; vertical-align:top;">
+        <td style="text-align:left; border:0; width:33%; vertical-align:top;">
             <div class="electric-title">POWER NOW</div>
             <div class="power-value"><span id="usenow">0</span>W</div>
         </td>
-        <td style="text-align:center; border:0; width=33%; vertical-align:top;">
+        <td style="text-align:center; border:0; width:34%; vertical-align:top;">
             <div class="electric-title">BALANCE</div>
             <div class="midtext"><span id="balance"></span></div>
         </td>
-        <td style="text-align:right; border:0; width=33%; vertical-align:top;">
+        <td style="text-align:right; border:0; width:33%; vertical-align:top;">
             <div class="electric-title">SOLAR PV</div>
             <div class="power-value" style="color:#dccc1f"><span id="solarnow">0</span>W</div>
         </td>

--- a/Modules/app/mysolarpv/mysolarpv.html
+++ b/Modules/app/mysolarpv/mysolarpv.html
@@ -34,15 +34,15 @@
 
     <table style="width:100%">
     <tr>
-        <td style="border:0;">
+        <td style="text-align:left; border:0; width=33%; vertical-align:top;">
             <div class="electric-title">POWER NOW</div>
             <div class="power-value"><span id="usenow">0</span>W</div>
         </td>
-        <td style="text-align:center; border:0; vertical-align:top;">
+        <td style="text-align:center; border:0; width=33%; vertical-align:top;">
             <div class="electric-title">BALANCE</div>
             <div class="midtext"><span id="balance"></span></div>
         </td>
-        <td style="text-align:right; border:0;">
+        <td style="text-align:right; border:0; width=33%; vertical-align:top;">
             <div class="electric-title">SOLAR PV</div>
             <div class="power-value" style="color:#dccc1f"><span id="solarnow">0</span>W</div>
         </td>

--- a/Modules/app/mysolarpv/mysolarpv.html
+++ b/Modules/app/mysolarpv/mysolarpv.html
@@ -38,7 +38,7 @@
             <div class="electric-title">POWER NOW</div>
             <div class="power-value"><span id="usenow">0</span>W</div>
         </td>
-        <td style="text-align:left; border:0;">
+        <td style="text-align:center; border:0; vertical-align:top;">
             <div class="electric-title">BALANCE</div>
             <div class="midtext"><span id="balance"></span></div>
         </td>


### PR DESCRIPTION
Not sure if you intended "BALANCE" to be in alignment with "POWER NOW" and "SOLAR PV", but if so, then this aligns all three, and centres text within the middle cell.  
Paul
